### PR TITLE
Adding Behat testing instructions, allowing behat tests to change con…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,7 @@ jobs:
            WEBROOT: /var/www/html/drupal-project/web
            GIT_EMAIL: "ci@thinkshout.com"
            GIT_NAME: "ThinkShout CI Bot"
+           IS_CIRCLE: TRUE
          cmd: ["/start.sh"]
        - image: mariadb:10.0
          environment:

--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ Test are run automatically on CircleCI, but can be run locally as well with:
 robo test
 ```
 
+For more information refer to the `behat/README.md` file.
+
 ## Updating contributed code
 
 ### Updating contrib modules

--- a/behat/README.md
+++ b/behat/README.md
@@ -1,0 +1,5 @@
+# How to use this folder
+
+1. Copy `behat.local.yml.sample` to `behat.local.yml`
+2. Update the `base_url`, `drupal_root`, and `drush: root` variables to match your local machine's values.
+3. In the root of this repository, run `robo test` -- this will automatically pull in your local behat settings.

--- a/web/sites/default/settings.php
+++ b/web/sites/default/settings.php
@@ -46,7 +46,7 @@ else {
 // drush/SITE.drush.inc) OR PANTHEON_ENVIRONMENT to determine if we should
 // enable file base config. We only use file based for local development.
 // We could use a module like config_devel locally as well.
-if (!(getenv('DRUPAL_INSTALL') || defined('PANTHEON_ENVIRONMENT'))) {
+if (!(getenv('DRUPAL_INSTALL') || defined('PANTHEON_ENVIRONMENT') || getenv('IS_CIRCLE'))) {
   // Bootstrap file based config.
   $settings['bootstrap_config_storage'] = array(
     'Drupal\Core\Config\BootstrapConfigStorageFactory',


### PR DESCRIPTION
…fig  on circle.

Work originally done in https://github.com/thinkshout/lvhn/pull/340/files

tests that created blocks and placed  them with the block layout page also attempted to create config files on circle, but circle isn't configured to allow that, and it shouldn't need  to be.