### PR TITLE
Do not install the page_cache module by default

### DIFF
--- a/config/core.extension.yml
+++ b/config/core.extension.yml
@@ -29,7 +29,6 @@ module:
   menu_ui: 0
   node: 0
   options: 0
-  page_cache: 0
   path: 0
   quickedit: 0
   rdf: 0


### PR DESCRIPTION
All of our sites use a CDN so this is not needed and seems to cause problems