### PR TITLE
Dotenv support for drupal-project

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -4,3 +4,4 @@ TS_CONFIG_DIR="../config"
 TS_INSTALL_PROFILE="config_installer"
 TS_WEB_ROOT=web
 TS_HOST_REPO=""
+DRUSH_OPTIONS_URI=""

--- a/README.md
+++ b/README.md
@@ -90,6 +90,16 @@ The structure of `DEFAULT_PRESSFLOW_SETTINGS` if you want to set it locally is:
 DEFAULT_PRESSFLOW_SETTINGS_={"databases":{"default":{"default":{"driver":"mysql","prefix":"","database":"","username":"root","password":"root","host":"localhost","port":3306}}},"conf":{"pressflow_smart_start":true,"pantheon_binding":null,"pantheon_site_uuid":null,"pantheon_environment":"local","pantheon_tier":"local","pantheon_index_host":"localhost","pantheon_index_port":8983,"redis_client_host":"localhost","redis_client_port":6379,"redis_client_password":"","file_public_path":"sites\/default\/files","file_private_path":"sites\/default\/files\/private","file_directory_path":"site\/default\/files","file_temporary_path":"\/tmp","file_directory_temp":"\/tmp","css_gzip_compression":false,"js_gzip_compression":false,"page_compression":false},"hash_salt":"","config_directory_name":"sites\/default\/config","drupal_hash_salt":""}
 ```
 
+### Configure Drush
+
+Drush options can be configured in the `.env` file. For example, to set a default uri for commands like `drush uli`, add this:
+
+```
+DRUSH_OPTIONS_URI="https://web.new-project-name.localhost"
+```
+
+[Drush configuration docs](https://github.com/drush-ops/drush/blob/master/docs/using-drush-configuration.md)
+
 ### Installing
 
 Running the robo install command will run composer install to add all required

--- a/composer.json
+++ b/composer.json
@@ -55,6 +55,7 @@
         "drush/drush": "^10.0",
         "symfony/config": "^3.4.0",
         "symfony/dependency-injection": "^3.4.0",
+        "vlucas/phpdotenv": "^2.4",
         "webflo/drupal-finder": "^1.2",
         "webmozart/path-util": "^2.3"
     },
@@ -87,7 +88,8 @@
     "autoload": {
         "classmap": [
             "scripts/composer/ScriptHandler.php"
-        ]
+        ],
+        "files": ["load.environment.php"]
     },
     "scripts": {
         "drupal-scaffold": "DrupalComposer\\DrupalScaffold\\Plugin::scaffold",

--- a/load.environment.php
+++ b/load.environment.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * This file is included very early. See autoload.files in composer.json and
+ * https://getcomposer.org/doc/04-schema.md#files
+ */
+
+use Dotenv\Dotenv;
+use Dotenv\Exception\InvalidPathException;
+
+/**
+ * Load any .env file. See /.env.example.
+ */
+$dotenv = new Dotenv(__DIR__);
+try {
+  $dotenv->load();
+}
+catch (InvalidPathException $e) {
+  // Do nothing. Production environments rarely use .env files.
+}


### PR DESCRIPTION
Pulling this in from https://github.com/drupal-composer/drupal-project/pull/351

My main use case for this is to enable drush options to be configured via the project's `.env` file... like this:

```
DRUSH_OPTIONS_URI=https://web.tt.localhost
```