### PR TITLE
Removing pinned symfony dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,8 +53,6 @@
         "drupal/smart_trim": "^1.1",
         "drupal/token": "^1.1",
         "drush/drush": "^10.0",
-        "symfony/config": "^3.4.0",
-        "symfony/dependency-injection": "^3.4.0",
         "webflo/drupal-finder": "^1.2",
         "webmozart/path-util": "^2.3"
     },


### PR DESCRIPTION
As far as I can tell, these dependencies are not directly used by thinkshout/drupal-project, and they are causing headaches when attempting to update packages that depend on them