### PR TITLE
Drupal recommends update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,72 +1,27 @@
 {
-    "name": "thinkshout/drupal-project",
-    "description": "ThinkShout's project template for Drupal 8 projects with composer",
+    "name": "drupal/recommended-project",
+    "description": "Project template for Drupal 8 projects with a relocated document root",
     "type": "project",
-    "license": "GPL-2.0+",
-    "authors": [
+    "license": "GPL-2.0-or-later",
+    "homepage": "https://www.drupal.org/project/drupal",
+    "support": {
+        "docs": "https://www.drupal.org/docs/user_guide/en/index.html",
+        "chat": "https://www.drupal.org/node/314178"
+    },
+    "repositories": [
         {
-            "name": "ThinkShout",
-            "role": "Developer"
-        }
-    ],
-    "repositories": {
-        "asset-packagist": {
-            "type": "composer",
-            "url": "https://asset-packagist.org"
-        },
-        "drupal": {
             "type": "composer",
             "url": "https://packages.drupal.org/8"
         }
-    },
+    ],
     "require": {
-        "php": "^7.2",
         "composer/installers": "^1.2",
-        "cweagans/composer-patches": "^1.6",
-        "drupal-composer/drupal-scaffold": "^2.2",
-        "drupal/admin_toolbar": "^2.2",
-        "drupal/config_installer": "^1.8",
-        "drupal/config_split": "^1.3",
-        "drupal/editor_advanced_link": "^1.4",
-        "drupal/email_registration": "^1.0-rc5",
-        "drupal/fast_404": "^1.0-alpha3",
-        "drupal/field_group": "^3.0-beta1",
-        "drupal/honeypot": "^1.27",
-        "drupal/inline_entity_form": "^1.0-rc1",
-        "drupal/linkit": "^5.0.0-beta7",
-        "drupal/menu_block": "^1.5",
-        "drupal/metatag": "^1.5",
-        "drupal/migrate_google_sheets": "^1.0",
-        "drupal/migrate_plus": "^4.0-beta3",
-        "drupal/migrate_tools": "^4.0-beta3",
-        "drupal/pathauto": "^1.2",
-        "drupal/redirect": "^1.2",
-        "drupal/redis": "^1.0",
-        "drupal/simple_sitemap": "^2.12",
-        "drupal/smart_trim": "^1.1",
-        "drush/drush": "^10.0",
-        "symfony/config": "^3.4.0",
-        "symfony/dependency-injection": "^3.4.0",
-        "webflo/drupal-finder": "^1.2",
-        "webmozart/path-util": "^2.3",
-        "zaporylie/composer-drupal-optimizations": "^1.1"
+        "drupal/core-composer-scaffold": "^8.8",
+        "drupal/core-project-message": "^8.8",
+        "drupal/core-recommended": "^8.8"
     },
     "require-dev": {
-        "behat/mink": "~1.7",
-        "behat/mink-goutte-driver": "~1.2",
-        "dmore/behat-chrome-extension": "^1.1",
-        "drupal/coder": "^8.2",
-        "drupal/config_suite": "^1.1",
-        "drupal/console": "^1.9",
-        "drupal/devel": "^1.0-rc1",
-        "drupal/stage_file_proxy": "1.x-dev",
-        "drupal/twig_xdebug": "^1.0",
-        "drush-ops/behat-drush-endpoint": "dev-master",
-        "jcalderonzumba/gastonjs": "^1.1@dev",
-        "jcalderonzumba/mink-phantomjs-driver": "~0.3.1",
-        "mikey179/vfsstream": "~1.2",
-        "phpunit/phpunit": ">=4.8.28 <5",
-        "thinkshout/robo-drupal": "^v2.0.2"
+        "drupal/core-dev": "^8.8"
     },
     "conflict": {
         "drupal/drupal": "*"
@@ -76,63 +31,39 @@
     "config": {
         "sort-packages": true
     },
-    "autoload": {
-        "classmap": [
-            "scripts/composer/ScriptHandler.php"
-        ],
-        "files": ["load.environment.php"]
-    },
-    "scripts": {
-        "drupal-scaffold": "DrupalComposer\\DrupalScaffold\\Plugin::scaffold",
-        "pre-install-cmd": [
-            "DrupalProject\\composer\\ScriptHandler::checkComposerVersion"
-        ],
-        "pre-update-cmd": [
-            "DrupalProject\\composer\\ScriptHandler::checkComposerVersion"
-        ],
-        "post-install-cmd": [
-            "DrupalProject\\composer\\ScriptHandler::createRequiredFiles"
-        ],
-        "post-update-cmd": [
-            "DrupalProject\\composer\\ScriptHandler::createRequiredFiles"
-        ]
-    },
     "extra": {
-        "installer-paths": {
-            "web/core": [
-                "type:drupal-core"
-            ],
-            "web/libraries/{$name}": [
-                "type:drupal-library"
-            ],
-            "web/modules/contrib/{$name}": [
-                "type:drupal-module"
-            ],
-            "web/profiles/contrib/{$name}": [
-                "type:drupal-profile"
-            ],
-            "web/themes/contrib/{$name}": [
-                "type:drupal-theme"
-            ],
-            "drush/contrib/{$name}": [
-                "type:drupal-drush"
-            ]
-        },
-        "patches": {
-            "drupal/core": {
-                "Database::startLog() cause a notice in Shortcut::sort()": "https://www.drupal.org/files/issues/2019-12-05/2567035-51.patch",
-                "Plugin Lazy loading can cause usort warning": "https://www.drupal.org/files/issues/2699157-23.drupal.Plugin-Lazy-loading-can-cause-usort-warning.patch"
-            },
-            "drupal/ctools": {
-                "Views exposed filters missing autosubmit option https://www.drupal.org/node/2475595": "https://www.drupal.org/files/issues/2475595-ctools-autocomplete-fix-24.patch"
+        "drupal-scaffold": {
+            "locations": {
+                "web-root": "web/"
             }
         },
-        "patchLevel": {
-            "drupal/core": "-p2"
+        "installer-paths": {
+            "web/core": ["type:drupal-core"],
+            "web/libraries/{$name}": ["type:drupal-library"],
+            "web/modules/contrib/{$name}": ["type:drupal-module"],
+            "web/profiles/contrib/{$name}": ["type:drupal-profile"],
+            "web/themes/contrib/{$name}": ["type:drupal-theme"],
+            "drush/Commands/contrib/{$name}": ["type:drupal-drush"],
+            "web/modules/custom/{$name}": ["type:drupal-custom-module"],
+            "web/themes/custom/{$name}": ["type:drupal-custom-theme"]
         },
-        "drupal-scaffold": {
-            "excludes": [
-                ".htaccess"
+        "drupal-core-project-message": {
+            "include-keys": ["homepage", "support"],
+            "post-create-project-cmd-message": [
+                "<bg=blue;fg=white>                                                         </>",
+                "<bg=blue;fg=white>  Congratulations, you’ve installed the Drupal codebase  </>",
+                "<bg=blue;fg=white>  from the drupal/recommended-project template!          </>",
+                "<bg=blue;fg=white>                                                         </>",
+                "",
+                "<bg=yellow;fg=black>Next steps</>:",
+
+                "  * Install the site: https://www.drupal.org/docs/8/install",
+                "  * Read the user guide: https://www.drupal.org/docs/user_guide/en/index.html",
+                "  * Get support: https://www.drupal.org/support",
+                "  * Get involved with the Drupal community:",
+                "      https://www.drupal.org/getting-involved",
+                "  * Remove the plugin that prints this message:",
+                "      composer remove drupal/core-project-message"
             ]
         }
     }

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
         "drupal/core-recommended": "^8.8"
     },
     "require-dev": {
-        "drupal/core-dev": "^8.8"
+        "drupal/core-dev": "^8.8",
+        "thinkshout/robo-drupal": "^2.0"
     },
     "conflict": {
         "drupal/drupal": "*"


### PR DESCRIPTION
I'm just opening this for posterity. If we want to use the 8.8 recommended composer workflow and not the one we've been using up to now, we should fork a new repo or use Pantheon's Build tools.