### PR TITLE
Adding field_tools as a dev module.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,6 +56,7 @@
         "drupal/console": "^1.9",
         "drupal/devel": "^1.0-rc1",
         "drupal/drupal-extension": "^4.0",
+        "drupal/field_tools": "^1.0@alpha",
         "drupal/stage_file_proxy": "1.x-dev",
         "drupal/twig_xdebug": "^1.0",
         "drush-ops/behat-drush-endpoint": "dev-master",


### PR DESCRIPTION
**PR creator**
- Adds the field_tools module at https://www.drupal.org/project/field_tools to the list of dev tools we can enable locally.

**Reviewer**: https://docs.google.com/document/d/1auq5SyfFyVYcxJRNTV5-DTcjx-bBxO-dL2c99wiXJVs/edit
