### PR TITLE
Using the more drupally extension, which has things like a default aj…

### DIFF
--- a/behat/behat.ci.yml
+++ b/behat/behat.ci.yml
@@ -4,7 +4,7 @@
 #
 ci:
   extensions:
-    Behat\MinkExtension:
+    Drupal\MinkExtension:
       base_url: http://127.0.0.1/
     Drupal\DrupalExtension:
       drupal:

--- a/behat/behat.local.yml.sample
+++ b/behat/behat.local.yml.sample
@@ -5,7 +5,7 @@
 #
 local:
   extensions:
-    Behat\MinkExtension:
+    Drupal\MinkExtension:
       base_url: http://site.dev/
     Drupal\DrupalExtension:
       drupal:

--- a/behat/behat.yml
+++ b/behat/behat.yml
@@ -15,7 +15,7 @@ default:
         - Drupal\DrupalExtension\Context\DrushContext
   extensions:
     DMore\ChromeExtension\Behat\ServiceContainer\ChromeExtension: ~
-    Behat\MinkExtension:
+    Drupal\MinkExtension:
       goutte: ~
       browser_name: chrome
       sessions:


### PR DESCRIPTION
…ax timeout.

**PR creator**
This updates the version of the MinkExtension that we're using to be the one that is written in some Drupally things, instead of using the Behat default one. Among other things, this gives us the ability to perform ajax requests, which were timing out automatically due to https://github.com/jhedstrom/drupalextension/issues/486 previously

**Reviewer**: https://docs.google.com/document/d/1auq5SyfFyVYcxJRNTV5-DTcjx-bBxO-dL2c99wiXJVs/edit
