### PR TITLE
Rename production branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
             composer global require -n "consolidation/cgr"
             cgr "pantheon-systems/terminus:~2"
             COMPOSER_MEMORY_LIMIT=-1 composer install --prefer-dist
-            robo configure --db-name=drupal --db-user=drupal --db-pass=drupal --db-host=127.0.0.1 --prod-branch=production
+            robo configure --db-name=drupal --db-user=drupal --db-pass=drupal --db-host=127.0.0.1 --prod-branch=main
       - run:
           name: Install and test
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
             composer global require -n "consolidation/cgr"
             cgr "pantheon-systems/terminus:~2"
             COMPOSER_MEMORY_LIMIT=-1 composer install --prefer-dist
-            robo configure --db-name=drupal --db-user=drupal --db-pass=drupal --db-host=127.0.0.1
+            robo configure --db-name=drupal --db-user=drupal --db-pass=drupal --db-host=127.0.0.1 --prod-branch=production
       - run:
           name: Install and test
           command: |

--- a/README.md
+++ b/README.md
@@ -47,19 +47,14 @@ Initialize a repository on github https://github.com/new that matches your proje
 
 ```
 git init
+git checkout -b develop
 git add .
 git commit -m "Initial commit."
 git remote add origin git@github.com:thinkshout/new-project-name.git
-git push -u origin master
-```
-
-Rename the master branch to "production":
-
-```
+git push -u origin develop
 git checkout -b production
 git push --set-upstream origin production
-git branch -d master
-git push origin --delete master
+git checkout develop
 ```
 
 To initialize the project name in several of the files run:

--- a/README.md
+++ b/README.md
@@ -53,6 +53,15 @@ git remote add origin git@github.com:thinkshout/new-project-name.git
 git push -u origin master
 ```
 
+Rename the master branch to "production":
+
+```
+git checkout -b production
+git push --set-upstream origin production
+git branch -d master
+git push origin --delete master
+```
+
 To initialize the project name in several of the files run:
 
 ```
@@ -82,6 +91,8 @@ robo configure
 robo configure --db-pass=<YOUR LOCAL DATABASE PASSWORD>
 # Use an alternate DB name
 robo configure --db-name=<YOUR DATABASE NAME>
+# Use an alternate release/production/live branch name
+robo configure --prod-branch=<YOUR BRANCH NAME>
 ```
 
 The structure of `DEFAULT_PRESSFLOW_SETTINGS` if you want to set it locally is:

--- a/README.md
+++ b/README.md
@@ -52,9 +52,6 @@ git add .
 git commit -m "Initial commit."
 git remote add origin git@github.com:thinkshout/new-project-name.git
 git push -u origin develop
-git checkout -b production
-git push --set-upstream origin production
-git checkout develop
 ```
 
 To initialize the project name in several of the files run:

--- a/composer.json
+++ b/composer.json
@@ -119,7 +119,7 @@
         "patches": {
             "drupal/core": {
                 "Database::startLog() cause a notice in Shortcut::sort()": "https://www.drupal.org/files/issues/2019-12-05/2567035-51.patch",
-                "Plugin Lazy loading can cause usort warning": "https://www.drupal.org/files/issues/2699157-23.drupal.Plugin-Lazy-loading-can-cause-usort-warning.patch"
+                "Plugin Lazy loading can cause usort warning": "https://www.drupal.org/files/issues/2020-06-22/2699157-38.drupal.Plugin-Lazy-loading-can-cause-usort-warning.patch"
             },
             "drupal/ctools": {
                 "Views exposed filters missing autosubmit option https://www.drupal.org/node/2475595": "https://www.drupal.org/files/issues/2475595-ctools-autocomplete-fix-24.patch"

--- a/composer.json
+++ b/composer.json
@@ -64,7 +64,7 @@
         "jcalderonzumba/mink-phantomjs-driver": "~0.3.1",
         "mikey179/vfsstream": "~1.2",
         "phpunit/phpunit": ">=4.8.28 <5",
-        "thinkshout/robo-drupal": "^v2.0.2"
+        "thinkshout/robo-drupal": "^v3.0.0"
     },
     "conflict": {
         "drupal/drupal": "*"

--- a/composer.json
+++ b/composer.json
@@ -121,6 +121,9 @@
                 "Database::startLog() cause a notice in Shortcut::sort()": "https://www.drupal.org/files/issues/2019-12-05/2567035-51.patch",
                 "Plugin Lazy loading can cause usort warning": "https://www.drupal.org/files/issues/2020-06-22/2699157-38.drupal.Plugin-Lazy-loading-can-cause-usort-warning.patch"
             },
+            "drupal/config_suite": {
+                "Syntax error in ConfigSuiteImportSubscriber https://www.drupal.org/node/3189614": "https://git.drupalcode.org/project/config_suite/-/merge_requests/1.diff"
+            },
             "drupal/ctools": {
                 "Views exposed filters missing autosubmit option https://www.drupal.org/node/2475595": "https://www.drupal.org/files/issues/2475595-ctools-autocomplete-fix-24.patch"
             }


### PR DESCRIPTION
Not much here: and ~~this shouldn't be merged until this is merged:~~
https://github.com/thinkshout/robo-drupal/pull/65 (merged)

And a release is rolled that matches the version here (3.0.0) for robo drupal. (done)

This also updates instructions to avoid ending up with a "master" branch on new repositories, and set up develop while we are at it. (not necessary anymore, removed, because Github sets a better default)